### PR TITLE
base: Speedup image build doing a shallow clone of CMake repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,9 @@ RUN apt-get update && apt-get -y install \
 
 # Build and install CMake from source.
 WORKDIR /usr/src
-RUN git clone git://cmake.org/cmake.git CMake && \
+RUN git clone --branch v3.4.3 --depth 1 \
+     git://cmake.org/cmake.git CMake && \
   cd CMake && \
-  git checkout v3.4.3 && \
   cd .. && mkdir CMake-build && cd CMake-build && \
   /usr/src/CMake/bootstrap \
     --parallel=$(nproc) \


### PR DESCRIPTION
7.6MB vs 44.8MB
15s vs 1m20s

```
$ time git clone --branch v3.4.3 --depth 1  git://cmake.org/cmake.git CMake
Cloning into 'CMake'...
[...]
Receiving objects: 100% (8693/8693), 7.62 MiB | 578.00 KiB/s, done.
[...]
real	0m15.387s
user	0m0.516s
sys	0m0.280s

$ time git clone  git://cmake.org/cmake.git CMake
Cloning into 'CMake'...
[...]
Receiving objects: 100% (188990/188990), 44.88 MiB | 372.00 KiB/s, done.
[...]
real	1m20.506s
user	0m8.884s
sys	0m1.680s
```