### PR TITLE
linux-ppc64le: Specify system processor and fix library finding.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,7 @@ thewtex/cross-compiler-linux-x64
   :target: https://imagelayers.io/?images=thewtex/cross-compiler-linux-x86:latest
 
 thewtex/cross-compiler-linux-x86
-  |linux-x86-images| Linux i686 compiler. Since the Docker image is
-  natively x86_64 with i386 multi-arch support, this is not actually a cross compiler.
+  |linux-x86-images| Linux i686 cross compiler.
 
 
 .. |windows-x64-images| image:: https://badge.imagelayers.io/thewtex/cross-compiler-windows-x64:latest.svg

--- a/linux-ppc64le/Dockerfile
+++ b/linux-ppc64le/Dockerfile
@@ -8,7 +8,11 @@ RUN echo "deb http://emdebian.org/tools/debian/ jessie main" >> /etc/apt/sources
 
 RUN apt-get update && apt-get install -y \
   crossbuild-essential-ppc64el \
-  gfortran-powerpc64le-linux-gnu
+  gfortran-powerpc64le-linux-gnu \
+  libbz2-dev:ppc64el \
+  libexpat1-dev:ppc64el \
+  ncurses-dev:ppc64el \
+  libssl-dev:ppc64el
 
 WORKDIR /usr/src
 

--- a/linux-ppc64le/Toolchain.cmake
+++ b/linux-ppc64le/Toolchain.cmake
@@ -1,5 +1,6 @@
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR ppc64le)
 
 set(cross_triple "powerpc64le-linux-gnu")
 
@@ -7,9 +8,8 @@ set(CMAKE_C_COMPILER /usr/bin/${cross_triple}-cc)
 set(CMAKE_CXX_COMPILER /usr/bin/${cross_triple}-c++)
 set(CMAKE_Fortran_COMPILER /usr/bin/${cross_triple}-gfortran)
 
-set(CMAKE_FIND_ROOT_PATH /usr/${cross_triple})
-set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+# Discard path returned by pkg-config and associated with HINTS in module
+# like FindOpenSSL.
+set(CMAKE_IGNORE_PATH /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu/lib/)
 
 set(CMAKE_CROSSCOMPILING_EMULATOR /usr/bin/qemu-ppc64le)


### PR DESCRIPTION
This commit updates the toolchain to ensure libraries associated with
ppc64le can be found.

Since the libraries are all installed on the system and not in dedicated
root, `FIND_ROOT_PATH` should *not* be specified.